### PR TITLE
Connect scrape pub to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,17 +103,18 @@ $ medium-stats scrape_user -u [USERNAME] --all
 
 For a publication:
 ```bash
-$ medium-stats scrape_publication -u [URL] --all
+$ medium-stats scrape_publication -u [USERNAME] -s [SLUG] --all
 
-# Valid example urls: 
-# 'https://medium.com/test-publication', 'medium.com/test-publication', 
-# 'https://custom.subdomain.com', 'custom.subdomain.com'
+# The "slug" parameter is typically your publication's name in lower-case,
+# with spaces delimited by dashes, and is the portion of your page's URL after "medium.com/"
+# e.g. "test-publication" if the URL is https://medium.com/test-publication and name is "Test Publication"
+
 ```
 
 General Use pattern:
 ```bash
-medium-stats (scrape_user | scrape_publication) -u USERNAME/URL [--output_dir DIR] \
-(--creds PATH | (--sid SID --uid UID)) \
+medium-stats (scrape_user | scrape_publication) -u USERNAME/URL -s [PUBLICATION_SLUG]
+[--output_dir DIR] (--creds PATH | (--sid SID --uid UID)) \
 (--all | [--start PERIOD_START] [--end PERIOD END]) [--is-utc] \
 [--mode {summary, events, articles, referrers, story_overview}]
 ```

--- a/medium_stats/__main__.py
+++ b/medium_stats/__main__.py
@@ -209,7 +209,7 @@ def main():
                 write_stats(sg, data, 'summary', sg.now, sub_dir)
             
         else:
-            url = args.u
+            url = args.s
             sg = StatGrabberPublication(url, sid, uid, args.start, args.end, already_utc=True)
             folders = get_folders(pub_mode_attrs)
             sub_dir = create_directories(args.output_dir, sg.slug, folders)

--- a/medium_stats/cli.py
+++ b/medium_stats/cli.py
@@ -5,6 +5,7 @@ import configparser
 from inspect import cleandoc
 from medium_stats.utils import valid_date, make_utc_explicit
 from functools import partial
+from inspect import cleandoc
 
 USER_MODE_CHOICES = ['summary', 'events', 'articles', 'referrers']
 PUB_MODE_CHOICES = ['events', 'story_overview', 'articles', 'referrers']
@@ -81,15 +82,18 @@ def get_argparser():
     
     # PUBLICATION
     usage = '''\
-    medium-stats scrape_publication -u URL [--output_dir DIR] \
+    medium-stats scrape_publication -u USERNAME -s PUBLICATION_SLUG [--output_dir DIR] \
     (--creds PATH | (--sid SID --uid UID)) \
-    (--all | [--start PERIOD_START] [--end PERIOD END]) [--is-utc]\
+    (--all | [--start PERIOD_START] [--end PERIOD_END]) [--is-utc]\
     [--mode {events, story_overview, articles, referrers}]'''
     usage = usage.replace('    ', '')
 
     scrape_pub = subparser.add_parser('scrape_publication', usage=usage, help='get publication statistics')
-    # TODO - change help below
-    scrape_pub.add_argument('-u', metavar='URL', help='publication URL')
+    scrape_pub.add_argument('-u', metavar='USERNAME', help='your Medium username')
+    slug_msg = ''' 
+    publication slug, e.g. "publication-name" if url is "medium.com/publication-name"
+    '''
+    scrape_pub.add_argument('-s', metavar='PUBLICATION_SLUG', help=cleandoc(slug_msg))
     add_subarguments(scrape_pub)
     scrape_pub.add_argument('--mode', nargs='*', 
                         choices=PUB_MODE_CHOICES, default=PUB_MODE_CHOICES, 
@@ -138,6 +142,8 @@ def parse_scraper_args(args, parser):
     if args.end < args.start:
         parser.error('Period "--end" cannot be prior to "--start"')
     
+    args.s = f'medium.com/{args.s}'
+
     return args
 
 class MediumConfigHelper:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name='medium-stats',
-    version='2.1.0',
+    version='2.1.1',
     entry_points={
         'console_scripts': [
             'medium-stats = medium_stats.__main__:main'


### PR DESCRIPTION
Ties credential file check for scrape_publication CLI command back to the username that the publication is associated with.  

Previously each publication needed it's own section in the credentials file which meant that if a User had several publications under the same account, their "sid" and "uid" cookies needed to be duplicated across many sections.